### PR TITLE
CMake changes and CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: Build
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+    native:
+        runs-on: "ubuntu-latest"
+        steps:
+        - uses: actions/checkout@v4
+        - name: "apt-get install"
+          run: |
+            sudo apt-get update
+            sudo apt-get -y install cmake libqt5charts5-dev libfftw3-dev
+        - name: cmake
+          run: cmake -S . -B build
+        - name: build
+          run: cmake --build build -j2 -v

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,27 @@
-cmake_minimum_required(VERSION 3.27)
+cmake_minimum_required(VERSION 3.22)
 project(viewer)
+
+find_package(PkgConfig)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-
 find_package(Qt5 COMPONENTS
         Core
+        OPTIONAL_COMPONENTS
         Gui
         Widgets
         Charts
-        REQUIRED)
+)
+
+if(NOT Qt5Core_FOUND)
+        message(SEND_ERROR "Missing required Qt5Core")
+endif()
+
+if(Qt5Gui_FOUND AND Qt5Widgets_FOUND AND Qt5Charts_FOUND)
+message(STATUS "Build Viewer")
 
 add_executable(viewer main.cpp
         ViewerMainWin.cpp
@@ -94,14 +103,23 @@ add_executable(viewer main.cpp
         DataMediatorFac.h
 )
 
-include_directories(/usr/include/c++/10
-        /home/osprey/fftw/include)
+pkg_check_modules(FFTW REQUIRED IMPORTED_TARGET fftw3)
 
 target_link_libraries(viewer
         Qt5::Core
         Qt5::Gui
         Qt5::Widgets
         Qt5::Charts
-        /home/osprey/fftw/lib/libfftw3.so
+        PkgConfig::FFTW
 )
 
+install(
+        TARGETS viewer
+        RUNTIME DESTINATION bin
+)
+
+else()
+        message(STATUS "Skip Viewer")
+endif()
+
+add_subdirectory(fileReformatter2)

--- a/fileReformatter2/CMakeLists.txt
+++ b/fileReformatter2/CMakeLists.txt
@@ -1,16 +1,3 @@
-cmake_minimum_required(VERSION 3.28)
-project(FileReformatter2)
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTORCC ON)
-set(CMAKE_AUTOUIC ON)
-
-
-find_package(Qt5 COMPONENTS
-        Core
-        REQUIRED)
-
 add_executable(FileReformatter2 main.cpp
         BinFileType.cpp
         DataHeader.cpp
@@ -29,4 +16,7 @@ add_executable(FileReformatter2 main.cpp
 target_link_libraries(FileReformatter2
         Qt5::Core
 )
-
+install(
+        TARGETS FileReformatter2
+        RUNTIME DESTINATION bin
+)


### PR DESCRIPTION
Changes

- [x] Combine file converter and viewer into one build.  Allow build of file converter only
- [x] Add `install` targets
- [x] Use pkg-config to find FFTW to avoid hard coded path 
- [x] Add github actions CI build